### PR TITLE
Deployment GHA workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches: 
+      - master
+      - main
+      - features/gha
+
+jobs:
+  deploy:
+    name: Deploy to start.k8ssandra.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build project
+        shell: bash -e -l {0}
+        run: |
+          nvm install
+          npm install
+          npm run build
+      - name: Install gcloud CLI
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+      - name: Deploy to GCS
+        env:
+          GCP_BUCKET_NAME: ${{ secrets.GCP_BUCKET_NAME }}
+        run: |
+          gsutil -m cp -r ./* gs://$GCP_BUCKET_NAME/
+        working-directory: dist/


### PR DESCRIPTION
Added support for deploying to GCS when pushing to the `main` or `master` branches.