### PR TITLE
Removed default space in DC name

### DIFF
--- a/src/components/Topology.vue
+++ b/src/components/Topology.vue
@@ -20,7 +20,7 @@
                 :rules="[rules.required]"
             >
               <template v-slot:prepend>
-                <label>Data Centers*</label>
+                <label>Datacenter Name*</label>
               </template>
             </v-text-field>
         </div>

--- a/src/json/templates.json
+++ b/src/json/templates.json
@@ -3,7 +3,7 @@
     "updateName": "",
     "updateDescription": "",
     "addRacks": [],
-    "updateDataCenterName": " ",
+    "updateDataCenterName": "",
     "updateTotalClusterSize": 1,
     "updateVersion": "4.0.1",
     "updateAuthentication": false,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -35,7 +35,7 @@ export default new Vuex.Store({
           },
           "datacenters": [
             {
-              "name": " ",
+              "name": "",
               "size": 0,
               "racks": [],
             },
@@ -102,7 +102,7 @@ export default new Vuex.Store({
       state.settings.config.cassandra.auth.enabled = txt;
     },
     updateDataCenterName(state, txt) {
-      state.settings.config.cassandra.datacenters[0].name = ( txt ? txt : ' ');
+      state.settings.config.cassandra.datacenters[0].name = txt;
     },
     addRack(state, txt) {
       let rack = {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -17,7 +17,7 @@
 import Input from "@/components/Input.vue";
 import Result from "@/components/Result.vue";
 import LandingPage from "@/components/LandingPage.vue";
-import Restart from "../components/Restart";
+import Restart from "@/components/Restart";
 
 
 export default {


### PR DESCRIPTION
Renamed 'Datacenters' to 'Datacenter Name'
Fixed path to Restart component to align with other components